### PR TITLE
New module rfg-icon, get favicons and app icons from realfavicongenerator.net

### DIFF
--- a/modules/rfg-icon/README.md
+++ b/modules/rfg-icon/README.md
@@ -1,0 +1,39 @@
+# RealFaviconGenerator Icon
+[![npm](https://img.shields.io/npm/dt/@nuxtjs/rfg-icon.svg?style=flat-square)](https://www.npmjs.com/package/@nuxtjs/rfg-icon)
+[![npm (scoped with tag)](https://img.shields.io/npm/v/@nuxtjs/rfg-icon/latest.svg?style=flat-square)](https://www.npmjs.com/package/@nuxtjs/rfg-icon)
+
+> Automatically generates app icons and favicon with different sizes using [rfg-api](https://github.com/RealFaviconGenerator/rfg-api).
+
+- This module adds link and meta tags for the appropiate favicon's to `head`
+- The generated manifest.json is added to `manifest`, so does not overwrite existing properties
+
+## Setup
+- Add `@nuxtjs/rfg-icon` dependency using yarn or npm to your project
+- Add `@nuxtjs/rfg-icon` to `modules` section of `nuxt.config.js` _before_ `@nuxtjs/manifest`
+
+```js
+  modules: [
+    // Simple usage
+   '@nuxtjs/icon',
+   '@nuxtjs/manifest', 
+   
+   // With options
+   ['@nuxtjs/icon', { masterPicture: '' }],
+
+   // or use global options
+   'rfgicon': {
+      masterPicture: 'static/icon.png',
+   }
+  ]
+````
+- Create `static/icon.png`. Recommended to be square png and >= `512x512px`
+
+## Options
+
+### masterPicture
+- Default: `[srcDir]/static/icon.png`
+
+### other options
+
+See [realfavicongenerator.net](https://realfavicongenerator.net/) for a full list of options. Easiest is uploading your image on the website and choose your settings. Next click on `Generate favicons`, click on the tab `Node CLI` and copy the contents of the `faviconDescription.json` file to your `nuxt.config.js`
+

--- a/modules/rfg-icon/index.js
+++ b/modules/rfg-icon/index.js
@@ -1,0 +1,182 @@
+const { find, defaultsDeep } = require('lodash')
+const path = require('path')
+const rfg = require('rfg-api').init()
+const axios = require('axios')
+const unzip = require('unzip2')
+
+const defaults = {
+  apiKey: '402333a17311c9aa68257b9c5fc571276090ee56',
+  design: {
+    ios: {
+      pictureAspect: 'backgroundAndMargin',
+      backgroundColor: '#ffffff',
+      margin: '14%',
+      assets: {
+        ios6AndPriorIcons: false,
+        ios7AndLaterIcons: false,
+        precomposedIcons: false,
+        declareOnlyDefaultIcon: true
+      }
+    },
+    desktopBrowser: {},
+    windows: {
+      pictureAspect: 'whiteSilhouette',
+      backgroundColor: '#00a300',
+      onConflict: 'override',
+      assets: {
+        windows80Ie10Tile: false,
+        windows10Ie11EdgeTiles: {
+          small: false,
+          medium: true,
+          big: false,
+          rectangle: false
+        }
+      }
+    },
+    androidChrome: {
+      pictureAspect: 'noChange',
+      themeColor: '#ffffff',
+      manifest: {
+        display: 'standalone',
+        orientation: 'notSet',
+        onConflict: 'override',
+        declared: true
+      },
+      assets: {
+        legacyIcon: false,
+        lowResolutionIcons: false
+      }
+    },
+    safariPinnedTab: {
+      pictureAspect: 'silhouette',
+      themeColor: '#5bbad5'
+    }
+  },
+  settings: {
+    scalingAlgorithm: 'Mitchell',
+    errorOnImageTooSmall: false
+  }
+}
+
+const fixUrl = url => url.replace(/\/\//g, '/').replace(':/', '://')
+const isUrl = url => url.indexOf('http') === 0 || url.indexOf('//') === 0
+
+module.exports = function nuxtRfgIcon (options) {
+  let faviconDescription = defaultsDeep(this.options.rfgicon || options || {}, defaults)
+
+  faviconDescription.masterPicture = faviconDescription.masterPicture || path.resolve(this.options.srcDir, 'static', 'icon.png')
+
+  // routerBase and publicPath
+  const routerBase = this.options.router.base
+  let publicPath = fixUrl(`${routerBase}/${this.options.build.publicPath}`)
+  if (isUrl(this.options.build.publicPath)) { // CDN
+    publicPath = this.options.build.publicPath
+    if (publicPath.indexOf('//') === 0) {
+      publicPath = '/' + publicPath // escape fixUrl
+    }
+  }
+  faviconDescription.iconsPath = fixUrl(publicPath + '/icons/')
+
+  var request = rfg.createRequest(faviconDescription)
+
+  return axios.post('https://realfavicongenerator.net/api/favicon', {
+    favicon_generation: request
+  }, {
+    requestType: 'json'
+  }).then(({ data }) => {
+    return new Promise((resolve, reject) => {
+      var headers = data.favicon_generation_result.favicon.html_code
+
+      axios.get(data.favicon_generation_result.favicon.package_url, {
+        responseType: 'stream'
+      }).then(({ data }) => {
+        resolve({ data, headers })
+      }).catch(err => {
+        reject(err)
+      })
+    })
+  }).then(({ data, headers }) => {
+    return new Promise((resolve, reject) => {
+      var faviconFiles = []
+
+      var parserStream = unzip.Parse()
+      parserStream.on('close', () => {
+        if (faviconFiles.length) {
+          resolve({ faviconFiles, headers })
+        } else {
+          reject(new Error('zip file was empty'))
+        }
+      })
+
+      data.pipe(parserStream).on('entry', (entry) => {
+        var buffers = []
+
+        entry.on('data', (buffer) => { buffers.push(buffer) })
+        entry.on('end', () => {
+          faviconFiles.push({
+            fileName: entry.path,
+            buff: Buffer.concat(buffers)
+          })
+        })
+      })
+    })
+  }).then(({ faviconFiles, headers }) => {
+    // add link and meta's to head
+    if (!this.options.head) {
+      this.options.head = {}
+    }
+
+    var re = /(?:\s+)([^=\s]+)(?:=?"?([^>\s"]*))/g
+    headers.split('\n').forEach(header => {
+      var type = /<([^\s>]+)/.exec(header)[1]
+
+      if (type === 'link' || type === 'meta') {
+        if (!(this.options.head[type] instanceof Array)) {
+          this.options.head[type] = []
+        }
+
+        var attrs = {}
+        var match
+        while ((match = re.exec(header))) {
+          if (match[1] === 'rel' && match[2] === 'manifest') {
+            continue
+          }
+          if (match[1] === 'href' || match[1] === 'content') {
+            match[2] = fixUrl(match[2])
+          }
+          attrs[match[1]] = match[2]
+        }
+        this.options.head[type].push(attrs)
+      }
+    })
+
+    // apply manifest to current manifest, use defaults so you can still override values
+    var manifest = find(faviconFiles, { fileName: 'manifest.json' })
+    var manifestJson = JSON.parse(manifest.buff.toString('UTF-8'))
+    if (!this.options.manifest) {
+      this.options.manifest = {}
+    }
+    this.options.manifest = defaultsDeep(this.options.manifest, manifestJson)
+
+    // Register webpack plugin to emit icons
+    this.options.build.plugins.push({
+      apply (compiler) {
+        compiler.plugin('emit', function (compilation, _cb) {
+          faviconFiles.forEach(file => {
+            if (file.fileName !== 'manifest.json') {
+              compilation.assets['icons/' + file.fileName] = {
+                source: () => file.buff,
+                size: () => file.buff.length
+              }
+            }
+          })
+          _cb()
+        })
+      }
+    })
+  }).catch(err => {
+    console.error('[rfg-icon] error communicating with rfg api', err)
+  })
+}
+
+module.exports.meta = require('./package.json')

--- a/modules/rfg-icon/package.json
+++ b/modules/rfg-icon/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@nuxtjs/rfg-icon",
+  "version": "0.0.1",
+  "license": "MIT",
+  "description": "nuxtjs module for creating icons through RealFaviconGenerator",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "axios": "^0.16.2",
+    "lodash": "^4.17.4",
+    "path": "^0.12.7",
+    "rfg-api": "^0.3.0",
+    "unzip2": "^0.2.5"
+  }
+}


### PR DESCRIPTION
I was looking at the `@nuxtjs/icon` package today and unfortunately that package just does not cover all cases.  It only generates a manifest.json, but doesnt add the favicon meta/link headers. Looking further into favicons in general its quite a mess, so I thought instead of discovering the wheel again lets make use of the time others have spent looking into this.

Through this [question](https://stackoverflow.com/questions/2268204/favicon-dimensions) I came across [RealFaviconGenerator.net](https://realfavicongenerator.net), they provide an API with which you receive a zip file of all generated favicons based on the source image you sent (disclaimer, I am _not_ related to them). This module uses that api to retrieve the zip file and add the icons as assets, add them as link/meta tags in `head` and add them to `manifest`.

The only issue I see with this module at the moment is that I copied the design pattern from `@nuxtjs/icon` so that means the favicons / API response are not cached and the API is contacted every time you build your app.

That said I can image that you'd prefer not to add this module as it uses a third party api, so no hard feelings if you reject this `PR`. But in case you do like it we should probably contact them to ask their opinion (e.g with regards to the API key).

