### PR TITLE
[axios] added debug option to log all requests & responses

### DIFF
--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -124,6 +124,11 @@ You can also use environment variable `API_URL_BROWSER` which **overrides** `bro
 Adds an interceptor to automatically set `withCredentials` config of axios when requesting to `baseUrl`
 which allows passing authentication headers to backend. 
 
+### `debug`
+- Default: `false`
+
+Adds interceptors to log all responses and requests
+
 ### `proxyHeaders`
 - Default: `true`
 

--- a/modules/axios/index.js
+++ b/modules/axios/index.js
@@ -15,7 +15,8 @@ module.exports = function nuxtAxios (moduleOptions) {
     baseURL: `http://${host}:${port}/api`,
     browserBaseURL: null,
     credentials: true,
-    proxyHeaders: true
+    proxyHeaders: true,
+    debug: false
   }
 
   const options = Object.assign({}, defaults, this.options.axios, moduleOptions)

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -94,6 +94,24 @@ function errorHandler(error) {
   }
 }
 
+function debug(level, messages) {
+  if (!(console[level] instanceof Function)) {
+    level = 'info'
+    messages = arguments
+  } else {
+    level = arguments[0]
+    messages = Array.prototype.slice.call(arguments, 1)
+  }
+
+  if (!messages.length) {
+    console[level].call(null, '[@nuxtjs/axios] <empty debug message>')
+  } else {
+    for (var i = 0; i < messages.length; i++) {
+      console[level].call(null, messages[i])
+    }
+  }
+}
+
 export default (ctx) => {
   const { app, store, req } = ctx
 
@@ -115,6 +133,23 @@ export default (ctx) => {
       }
     }
     return config
+  });
+  <% } %>
+
+  <% if(options.debug) { %>
+  axios.interceptors.request.use(config => {
+    debug('[@nuxtjs/axios] Request:', config)
+    return config
+  }, error => {
+    debug('error', '[@nuxtjs/axios] Error:', error)
+    return Promise.reject(error)
+  });
+  axios.interceptors.response.use(config => {
+    debug('[@nuxtjs/axios] Response:', config)
+    return config
+  }, error => {
+    debug('error', '[@nuxtjs/axios] Error:', error)
+    return Promise.reject(error)
   });
   <% } %>
 


### PR DESCRIPTION
Idea taken from this package: https://github.com/andykingking/axios-debug

When you set `debug: true` all requests and responses are printed. I looked at the other modules and it seems at the moment there is no default implementation for logging, so I am directly calling `console.info`.

btw, I thought about checking for env debug but I think this is much to verbose so a separate debug option is reasonable

