### PR TITLE
Fix for scheme-less baseURL's

### DIFF
--- a/modules/axios/index.js
+++ b/modules/axios/index.js
@@ -30,11 +30,12 @@ module.exports = function nuxtAxios (moduleOptions) {
     options.browserBaseURL = process.env.API_URL_BROWSER
   }
 
+  const isSchemeLessBaseURL = options.baseURL.substr(0, 2) === '//'
   options.baseURL = new URL(options.baseURL, `http://${host}:${port}`)
 
   if (!options.browserBaseURL) {
     const sameHost = options.baseURL.host === `${host}:${port}`
-    options.browserBaseURL = sameHost ? options.baseURL.pathname : options.baseURL
+    options.browserBaseURL = sameHost ? options.baseURL.pathname : isSchemeLessBaseURL ? options.baseURL.toString().substr(5) : options.baseURL // 5 == 'http:'.length
   }
 
   // Register plugin


### PR DESCRIPTION
My dev setup is a bit strange with people locally connecting from http but remote with https through an nginx proxy. Unfortunately remote access wasnt working as for a relative url with a missing scheme part URL will use the scheme part of it's baseURL `http://${host}:${port}` and thus will always be set to http.

This caused people connecting over https from remote to receive 'blocked: mixed-content` errors.

In commit 19b8453473e205719b2ef81767a1ad6771cf4766 it was mentioned that e.g. the url `//google.com` was fixed, but I guess that it was only fixed by forcing to use http. A scheme-less url should be valid in (most/all?) browsers so only for SRR a scheme should be added, not in the browser. For reference see this [question](https://stackoverflow.com/questions/4831741/can-i-change-all-my-http-links-to-just)

I used `substr(5)` because we know for sure a scheme-less url was set to `http:` and substr is faster then eg `.replace(/http:/, '')`.