### PR TITLE
Setting custom fields for google analytics

### DIFF
--- a/modules/google-analytics/index.js
+++ b/modules/google-analytics/index.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra')
 const path = require('path')
 
 module.exports = function nuxtAnalytics(options) {

--- a/modules/google-analytics/plugin.js
+++ b/modules/google-analytics/plugin.js
@@ -17,6 +17,14 @@ export default ({app: {router}}) => {
   // Every time the route changes (fired on initialization too)
   router.afterEach((to, from) => {
     // We tell Google Analytic to add a page view
+    var settings = to.meta.analytics                  //TODO to.meta is undefined for the initial request
+    if (settings && typeof settings === 'object') {
+      for (var key in settings) {
+        if (settings.hasOwnProperty(key)) {
+          ga('set', key, settings[key])
+        }
+      }
+    }
     ga('set', 'page', to.fullPath)
     ga('send', 'pageview')
   })


### PR DESCRIPTION
This change add possibility to set custom fields for GA. Eg. expId and expVar.
Plugin checks ```to.meta.analytics``` and if it is present sets GA fields.

It is not yet working for the initial request because ```to.meta``` is undefined.