### PR TITLE
Fix for 39: When proxyHeaders dont copy host header

### DIFF
--- a/modules/axios/package.json
+++ b/modules/axios/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "chalk": "^2.0.1",
     "whatwg-url": "^6.1.0"
   }
 }

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -128,7 +128,7 @@ export default (ctx) => {
 
   const axios = Axios.create({
     baseURL,
-    <% if(options.proxyHeaders) { %>headers: (req && req.headers) ? req.headers : {} <% } %>
+    <% if(options.proxyHeaders) { %>headers: (req && req.headers) ? Object.assign({}, req.headers, {host: ''}) : {} <% } %>
   })
   <% if(options.credentials) { %>
   // Send credentials only to relative and API Backend requests


### PR DESCRIPTION
Fix for issue #39 as discussed there

Also added chalk as dependency because otherwise if you run `yarn link` the axios plugin cant find it.