### PR TITLE
Optionally disable error handling

### DIFF
--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -136,6 +136,15 @@ In SSR context, sets client request header as axios default request headers.
 This is useful for making requests which need cookie based auth on server side.
 Also helps making consistent requests in both SSR and Client Side code.
 
+### `handleErrors`
+- Default: `true`
+
+Adds an interceptor which will `statusCode` and `message` keys to the `error` object 
+and redirects 401 statuses to `/login`. In SSR context the handler will not reject the promise
+and therefore you cannot add your own interceptors. In those circumstances, or if you do not want
+this default behaviour, you can set this to `false` to disable this interceptor.
+
+
 ## Helpers
 ### `setHeader(name, value, scopes='common')`
 Axios instance has a helper to easily set any header.

--- a/modules/axios/index.js
+++ b/modules/axios/index.js
@@ -16,7 +16,8 @@ module.exports = function nuxtAxios (moduleOptions) {
     browserBaseURL: null,
     credentials: true,
     proxyHeaders: true,
-    debug: false
+    debug: false,
+    handleErrors: true
   }
 
   const options = Object.assign({}, defaults, this.options.axios, moduleOptions)

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -160,7 +160,9 @@ export default (ctx) => {
   <% } %>
 
   // Error handler
-  axios.interceptors.response.use(undefined, errorHandler.bind(ctx));
+  <% if(options.handleErrors) { %>
+    axios.interceptors.response.use(undefined, errorHandler.bind(ctx));
+  <% } %>
 
   // Make accessible using *.$axios
   app.$axios = axios


### PR DESCRIPTION
In relation to issue here: https://github.com/nuxt-community/modules/issues/73

It's be very helpful to simply disable this response interceptor that handles errors. On SSR I'd like to be able to try and refresh a JWT token before displaying a 403 page or whatever custom logic.

I can add documentation if you think this is OK?