### PR TITLE
Fix apple-touch-icon meta link

### DIFF
--- a/modules/meta/index.js
+++ b/modules/meta/index.js
@@ -45,6 +45,7 @@ module.exports = function nuxtMeta (_options) {
   // Favicon
   if (options.favicon === true) {
     options.favicon = options.icons && options.icons.length > 0 && options.icons[0].src
+    options.applefavicon = options.icons && options.icons.length > 0 && options.icons[3].src
   }
   if (options.favicon) {
     if (!find(this.options.head.link, 'rel', 'shortcut icon')) {
@@ -52,7 +53,7 @@ module.exports = function nuxtMeta (_options) {
     }
 
     if (!find(this.options.head.link, 'rel', 'apple-touch-icon')) {
-      this.options.head.link.push({ rel: 'apple-touch-icon', href: options.favicon })
+      this.options.head.link.push({ rel: 'apple-touch-icon', href: options.applefavicon })
     }
   }
 


### PR DESCRIPTION
**Issue** : 
The generated `apple-touch-icon` meta uses the 16*16 px favicon from the manifest.

**Fix** : 
Creating an `applefavicon` key in the `options` object with the correct link.