### PR TITLE
FIX: google-tag-manager default 'layer' should be set to 'dataLayer'

### DIFF
--- a/modules/google-tag-manager/index.js
+++ b/modules/google-tag-manager/index.js
@@ -2,7 +2,7 @@ const _ = require('lodash')
 const path = require('path')
 const defaults = {
   id: null,
-  layer: null,
+  layer: 'dataLayer',
   env: {
     gtm_auth: null,
     gtm_preview: null,


### PR DESCRIPTION
This is a sane default and makes GTM work out of the box. It also reflects README.md, which already suggests that `layer` is set to `dataLayer` (which is a bit of a gotcha if you aren't browsing the source).