### PR TITLE
Fix indentation of readme

### DIFF
--- a/modules/markdownit/README.md
+++ b/modules/markdownit/README.md
@@ -16,13 +16,13 @@ Using [markdownit-loader](https://github.com/nuxt-community/markdownit-loader) a
   // [optional] markdownit options
   // See https://github.com/markdown-it/markdown-it
   markdownit: {
-      preset: 'default',
-      linkify: true,
-      breaks: true,
-      use: [
-        'markdown-it-container',
-        'markdown-it-attrs'
-      ]
+    preset: 'default',
+    linkify: true,
+    breaks: true,
+    use: [
+      'markdown-it-container',
+      'markdown-it-attrs'
+    ]
   }
 }
 ```


### PR DESCRIPTION
While copying the configuration object of the readme out of [npm](https://www.npmjs.com/package/@nuxtjs/markdownit) there was a wrong indentation. Since most of the example included two spaces as indentation i used it there too.