### PR TITLE
Fix sitemap in production build

### DIFF
--- a/modules/sitemap/package.json
+++ b/modules/sitemap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxtjs/sitemap",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "index.js",
   "repository": "https://github.com/nuxt/modules",


### PR DESCRIPTION
Version tested on each mode:
- dev
- generate
- build & start

There are still few improvements to be made, but it works fine ;-)

TODO: we can find a better way to detect if the current command is "build", "start" or "generate".

