### PR TITLE
Workbox Precaching and strategies optimisation

### DIFF
--- a/modules/workbox/index.js
+++ b/modules/workbox/index.js
@@ -36,17 +36,17 @@ module.exports = function nuxtWorkbox (options) {
       '': fixUrl(publicPath)
     },
     runtimeCaching: [
+      // Cache routes if offline
+      {
+        urlPattern: fixUrl(routerBase + '/**'),
+        handler: 'networkFirst'
+      },
       // Cache other _nuxt resources runtime
       // They are hashed by webpack so are safe to loaded by cacheFirst handler
       {
         urlPattern: fixUrl(publicPath + '/**'),
         handler: 'cacheFirst'
       },
-      // Cache routes if offline
-      {
-        urlPattern: fixUrl(routerBase + '/**'),
-        handler: 'networkFirst'
-      }
     ]
   }, options)))
 

--- a/modules/workbox/index.js
+++ b/modules/workbox/index.js
@@ -31,6 +31,7 @@ module.exports = function nuxtWorkbox (options) {
     cacheId: process.env.npm_package_name + '_' + process.env.npm_package_version,
     clientsClaim: true,
     globPatterns: ['**\/*.{js,css,html,json}'],
+    globIgnores: '**/server-bundle.json',
     modifyUrlPrefix: {
       '': fixUrl(publicPath)
     },


### PR DESCRIPTION
Hey there,

The Workbox module for nuxt is great at providing a quick and easy "offline" version of a nuxt application, but I spotted two issues.

**1 - Server-Bundle.json being downloaded**
As the globPattern matches every .json files, the precache would retrieve and store server-bundle.json that is not required on client side.

**2 - Routes order is wrong**
The routes for runtime caching are being generated in the wrong order. If you goes offline, it doesn't change anything, as the "networkFirst" strategy will fail right away they move on to cache. But if you test your app with poor network conditions (or network throttling) you can see that even the precached files at being served with the second route, which uses the networkFirst strategy.

Changing the order of the two generated routes ensure that the cacheFirst strategy is applied to every /_nuxt/** assets (including the precached one).

Errors were spotted and corrected while working on a project I can't share, but if needed I can later work on a small PoC project to show the improvement of reversing the two routes