### PR TITLE
Support through the store set axios configuration

### DIFF
--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -74,6 +74,22 @@ export default {
 }
 ```
 
+### Store Options
+If you want your configuration in the server and the browser side at the same time take effect.
+
+```js
+// In store/axios.js
+export const state = () => {
+  return {
+    timeout: 1000,
+    headers: {
+      Authorization: '__TOKEN__'
+    },
+    // ... All axios configuration.
+  }
+}
+```
+
 ## Options
 You can pass options using module options or `axios` section in  `nuxt.config.js`
 
@@ -92,6 +108,11 @@ You can also use environment variable `API_URL_BROWSER` which **overrides** `bro
 - If `browserBaseURL` is not provided it defaults to `baseURL` value.
   - If hostname & port of `browserbaseURL` are equal to nuxt server, it defaults to relative part of `baseURL`.
     So if your nuxt application is being accessed under a different domain, requests go to same origin and prevents Cross-Origin problems.
+
+### `storeName`
+- Default: `axios`
+
+Use store to set axios options, store name.
 
 ### `credentials`
 - Default: `true`

--- a/modules/axios/index.js
+++ b/modules/axios/index.js
@@ -16,6 +16,7 @@ module.exports = function nuxtAxios (moduleOptions) {
     browserBaseURL: null,
     credentials: true,
     proxyHeaders: true,
+    storeName: 'axios',
     debug: false,
     redirectError: {}
   }

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -85,6 +85,13 @@ function debug(level, messages) {
 }
 <% } %>
 
+function isEmptyObject(e) {
+  let t;
+  for (t in e)
+    return !1;
+  return !0
+}
+
 // Setup BaseURL
 const baseURL = process.browser
   ? (process.env.API_URL_BROWSER || '<%= options.browserBaseURL %>')
@@ -93,17 +100,21 @@ const baseURL = process.browser
 export default (ctx) => {
   const { app, store, req } = ctx
 
+  let defaultHeaders = {}
+
   <% if(options.proxyHeaders) { %>
   // Default headers
-  const defaultHeaders = (req && req.headers) ? Object.assign({}, req.headers) : {}
+  defaultHeaders = (req && req.headers) ? Object.assign({}, req.headers) : {}
   delete defaultHeaders.host
   <% } %>
 
   // Create new axios instance
-  const axios = Axios.create({
-    baseURL,
-    <% if(options.proxyHeaders) { %>headers: defaultHeaders,<% } %>
-  })
+  const storeOptions = store.state['<%= options.storeName %>']
+  defaultHeaders = Object.assign({}, storeOptions.headers || {}, defaultHeaders)
+  const options = Object.assign({}, {
+    baseURL
+  }, storeOptions, (isEmptyObject(defaultHeaders) ? {} : {headers: defaultHeaders}))
+  const axios = Axios.create(options)
 
   <% if(options.credentials) { %>
   // Send credentials only to relative and API Backend requests


### PR DESCRIPTION
Through the store to solve axios instance server and browser-side inconsistencies.

通过store来解决axios实例服务端和浏览器端不一致的问题。

#89 and #81 