### PR TITLE
- option for setting custom request interceptor

### DIFF
--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -134,7 +134,7 @@ for example based on the store state
 
 ```js
 requestInterceptor: (config, store) => {
-  if (store.state.userId) {
+  if (store.state.token) {
     config.headers.common['Authorization'] = store.state.token
   }
   return config

--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -126,6 +126,21 @@ For example if you want redirecting all `401` errors to `/login` use:
 }
 ```
 
+### `requestInterceptor`
+- Default: `null`
+
+Function for manipulating axios requests. Useful for setting custom headers,
+for example based on the store state
+
+```js
+requestInterceptor: (config, store) => {
+  if (store.state.userId) {
+    config.headers.common['Authorization'] = store.state.token
+  }
+  return config
+}
+```
+
 ## Helpers
 ### `setHeader(name, value, scopes='common')`
 Axios instance has a helper to easily set any header.

--- a/modules/axios/README.md
+++ b/modules/axios/README.md
@@ -130,10 +130,10 @@ For example if you want redirecting all `401` errors to `/login` use:
 - Default: `null`
 
 Function for manipulating axios requests. Useful for setting custom headers,
-for example based on the store state
+for example based on the store state. The second argument is the nuxt context.
 
 ```js
-requestInterceptor: (config, store) => {
+requestInterceptor: (config, { store }) => {
   if (store.state.token) {
     config.headers.common['Authorization'] = store.state.token
   }

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -137,10 +137,9 @@ export default (ctx) => {
 
   <% if (options.requestInterceptor) { %>
   // Custom request interceptor
-  const reqInter = <%= options.requestInterceptor %>
+  const reqInter = <%= serialize(options.requestInterceptor) %>
   axios.interceptors.request.use(
-    (config) => reqInter(config, store),
-    (error) => Promise.reject(error)
+    (config) => reqInter(config, ctx)
   )
   <% } %>
 

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -137,7 +137,7 @@ export default (ctx) => {
 
   <% if (options.requestInterceptor) { %>
   // Custom request interceptor
-  const reqInter = <%= serialize(options.requestInterceptor) %>
+  const reqInter = <%= serialize(options.requestInterceptor).replace('requestInterceptor(', 'function(') %>
   axios.interceptors.request.use(
     (config) => reqInter(config, ctx)
   )

--- a/modules/axios/plugin.js
+++ b/modules/axios/plugin.js
@@ -135,6 +135,15 @@ export default (ctx) => {
   });
   <% } %>
 
+  <% if (options.requestInterceptor) { %>
+  // Custom request interceptor
+  const reqInter = <%= options.requestInterceptor %>
+  axios.interceptors.request.use(
+    (config) => reqInter(config, store),
+    (error) => Promise.reject(error)
+  )
+  <% } %>
+
   // Error handler
   axios.interceptors.response.use(undefined, errorHandler.bind(ctx));
 


### PR DESCRIPTION
This is useful option for adding custom headers for all requests based on the state of the store or some other values.

Can be also used for handling authorizations headers instead of setToken method which cannot be used on the server side in the current implementation.