### PR TITLE
Fix for serviceworker check

### DIFF
--- a/modules/workbox/plugin.js
+++ b/modules/workbox/plugin.js
@@ -1,5 +1,5 @@
 window.onNuxtReady(() => {
-  if (!'serviceWorker' in navigator) {
+  if (!('serviceWorker' in navigator)) {
     console.warn('serviceWorker is not supported')
     return
   }


### PR DESCRIPTION
ServiceWorker check was always resolving true in browsers that didn't support the feature