### PR TITLE
yandex-metrika: fix undefined vars, prevent race condition

### DIFF
--- a/modules/yandex-metrika/plugin.js
+++ b/modules/yandex-metrika/plugin.js
@@ -1,17 +1,20 @@
-try {
-  (w[c] = w[c] || []).push(function() {
-    window['yaCounter<%= options.id %>'] = new Ya.Metrika(<%= JSON.stringify(options) %>);
-  })(document, window, 'yandex_metrika_callbacks');
-} catch (e) {}
+export default ({ app }) => {
 
-export default ({app: {router}}) => {
-  if (!window['Ya'] || window['yaCounter<%= options.id %>']) {
-    console.warn('Yandex metrika is not available')
-    return
+  function create () {
+    try {
+      window['yaCounter<%= options.id %>'] = new Ya.Metrika(<%= JSON.stringify(options) %>)
+      app.router.afterEach(to => {
+        // We tell Yandex Metrika to add a page view
+        window['yaCounter<%= options.id %>'].hit(to.fullPath)
+      })
+    } catch (e) { }
   }
 
-  router.afterEach((to, from) => {
-    // We tell Yandex Metrika to add a page view
-    window['yaCounter<%= options.id %>'].hit(to.fullPath)
-  })
+  if (window.Ya && window.Ya.Metrika) {
+    create()
+  } else {
+    (function (w, c) {
+      (w[c] = w[c] || []).push(create)
+    })(window, 'yandex_metrika_callbacks')
+  }
 }


### PR DESCRIPTION
The current yandex-metrika plugin is completely broken, I don't know how it landed in the repository in this shape. Consider the current source code: <https://github.com/nuxt-community/modules/blob/72f0982d6fe85b191941ce3b59f4f909fb355c2e/modules/yandex-metrika/plugin.js>.

In the following code, `w` and `c` are undefined, it will never work:

```js
try {
  (w[c] = w[c] || []).push(function() {
    window['yaCounter<%= options.id %>'] = new Ya.Metrika(<%= JSON.stringify(options) %>);
  })(document, window, 'yandex_metrika_callbacks');
} catch (e) {}
```

This was supposed to be wrapped in `(function (d, w, c) {` (hence the corresponding parameters) but that was lost somehow.

Then, this condition:

```js
  if (!window['Ya'] || window['yaCounter46006413']) {
    console.warn('Yandex metrika is not available')
    return
  }
```

is obviously reversed by mistake (the intent was to fail when `yaCounterXXX` was **not** available).

Now then, even if these both problems are fixed, the plugin suffers from the race condition. It depends on <https://mc.yandex.ru/metrika/watch.js> being executed strictly **after** Nuxt's compiled `app.js` (and picking up `yandex_metrika_callbacks`), which isn't always the case and could be the other way around.