### PR TITLE
Fix yandex-metrika ReferenceError and duplicate hits

### DIFF
--- a/modules/yandex-metrika/plugin.js
+++ b/modules/yandex-metrika/plugin.js
@@ -1,19 +1,31 @@
 export default ({ app: { router } }) => {
+  let ready = false
+
+  router.onReady(() => {
+    // Mark when the router has completed the initial navigation.
+    ready = true
+  })
+
   function create() {
-    try {
-      window['yaCounter<%= options.id %>'] = new Ya.Metrika(<%= JSON.stringify(options) %>)
-      app.router.afterEach(to => {
-        // We tell Yandex Metrika to add a page view
-        window['yaCounter<%= options.id %>'].hit(to.fullPath)
+    window['yaCounter<%= options.id %>'] = new Ya.Metrika(<%= JSON.stringify(options) %>)
+    router.afterEach((to, from) => {
+      if (!ready) {
+        // Don't record a duplicate hit for the initial navigation.
+        return
+      }
+      window['yaCounter<%= options.id %>'].hit(to.fullPath, {
+        referer: from.fullPath
+        // TODO: pass title: <new page title>
+        // This will need special handling because router.afterEach is called *before* DOM is updated.
       })
-    } catch (e) {
-      //
-    }
+    })
   }
 
   if (window.Ya && window.Ya.Metrika) {
+    // Yandex.Metrika API is already available.
     create()
   } else {
+    // Yandex.Metrika has not loaded yet, register a callback.
     (function (w, c) {
       (w[c] = w[c] || []).push(create)
     })(window, 'yandex_metrika_callbacks')


### PR DESCRIPTION
This is the second iteration of Yandex.Metrika fixes after #143:

- Fix `ReferenceError` coming from inaccurate use of function arguments `({app: { router }})` and variable reference `app.router`.
- Remove `try/catch` block that silences everything (including the error above) for no apparent reason.
- Fix duplicate metrika hit sent for the initial vue-router navigation.
- Send referer data along with the hit (in accordance with https://yandex.com/support/metrica/code/ajax-flash.html).