### PR TITLE
Bump version of bootstrap-vue to 1.0.0

### DIFF
--- a/packages/bootstrap-vue/package.json
+++ b/packages/bootstrap-vue/package.json
@@ -9,6 +9,6 @@
     "access": "public"
   },
   "dependencies": {
-    "bootstrap-vue": "^1.0.0-beta.7"
+    "bootstrap-vue": "^1.0.0"
   }
 }


### PR DESCRIPTION
Released: 2017-11-05
https://bootstrap-vue.js.org/docs/misc/changelog
(New version seems to work fine)