### PR TITLE
Module for i18n routing

### DIFF
--- a/packages/i18n-routes/README.md
+++ b/packages/i18n-routes/README.md
@@ -1,0 +1,50 @@
+# i18n-routes
+
+Create language-specific routes when using [vue-i18n](https://github.com/kazupon/vue-i18n).
+
+Given a page "foo":
+```
+└── pages
+    └── foo.vue
+```
+This module will dynamically generate routes for a set of languages:
+- **/en/foo**: English version of the "foo" page.
+- **/de/foo**: German version of the "foo" page.
+- **/foo**: This page will detect the user's language on the *client side* and redirect to the appropriate language-URL.
+
+Those routes will also be generated when rendering in SSR mode.
+
+## Compatibility
+
+Tested with Nuxt *1.0.0-rc11*.
+
+## Setup
+- Add `@nuxtjs/i18n-routes` dependency using yarn or npm to your project
+- Add `@nuxtjs/i18n-routes` to `modules` section of `nuxt.config.js` and define the languages to use:
+```js
+{
+  modules: [
+    ['@nuxtjs/i18n-routes', {
+      languages: ['en', 'de']
+    }]
+  ]
+}
+```
+- Create files `assets/locale/en.json` and `assets/locale/de.json` with your global translation phrases.
+For example:
+```json
+{
+  "hello-world": "Hallo Welt!"
+}
+```
+
+## Usage in components
+To point to a URL in the currently active language, use `localePath()`:
+```html
+<nuxt-link :to="localePath('/foo')">Foo</nuxt-link>
+```
+
+To translate a phrase, use vue-i18n's `$t()`:
+```html
+<h1>{{ $t('hello-world') }}</h1>
+```

--- a/packages/i18n-routes/index.js
+++ b/packages/i18n-routes/index.js
@@ -1,0 +1,65 @@
+const {resolve} = require('path')
+const pathToRegexp = require('path-to-regexp')
+
+module.exports = function (moduleOptions) {
+  const defaults = {
+    languages: ['en']
+  }
+  moduleOptions = Object.assign({}, defaults, moduleOptions)
+
+  // Add middleware
+  this.addTemplate({
+    src: resolve(__dirname, './templates/middleware.js'),
+    fileName: 'i18n-routes.middleware.js',
+    options: moduleOptions
+  })
+  this.options.router.middleware.push('i18n-routes')
+
+  // Add plugin
+  this.addPlugin({
+    src: resolve(__dirname, './templates/plugin.js'),
+    fileName: 'i18n-routes.plugin.js',
+    options: moduleOptions
+  })
+
+  // Add routes for router
+  this.extendRoutes(function (routes) {
+    routes.sort((a, b) => {
+      return b['path'].length - a['path'].length
+    })
+    routes.forEach(route => {
+      const {path} = route
+      route.path = `/:lang(\\w{2})?${path}`
+    })
+    return routes
+  })
+
+  // Add routes to generate
+  function flatRoutes (router, path = '', routes = []) {
+    router.forEach((r) => {
+      if (r.children) {
+        flatRoutes(r.children, path + r.path + '/', routes)
+      } else {
+        routes.push((r.path === '' && path[path.length - 1] === '/' ? path.slice(0, -1) : path) + r.path)
+      }
+    })
+    return routes
+  }
+  this.nuxt.plugin('generator', generator => {
+    generator.plugin('generateRoutes', ({generateRoutes}) => {
+      let routes = flatRoutes(this.options.router.routes)
+      routes = routes.filter((route) => {
+        let tokens = pathToRegexp.parse(route)
+        let params = tokens.filter((token) => typeof token === 'object')
+        return params.length === 1 && params[0].name === 'lang'
+      })
+      routes.forEach((route) => {
+        let toPath = pathToRegexp.compile(route)
+        let languageParamList = moduleOptions.languages.concat(null)
+        languageParamList.forEach((languageParam) => {
+          generateRoutes.push(toPath({lang: languageParam}))
+        })
+      })
+    })
+  })
+}

--- a/packages/i18n-routes/package.json
+++ b/packages/i18n-routes/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@nuxtjs/i18n-routes",
+  "version": "0.0.1",
+  "license": "MIT",
+  "main": "index.js",
+  "repository": "https://github.com/nuxt/modules",
+  "homepage": "https://github.com/nuxt/modules/tree/master/modules/i18n-routes",
+  "dependencies": {
+    "vue-i18n": "^7.3.2",
+    "path-to-regexp": "^2.1.0"
+  }
+}

--- a/packages/i18n-routes/templates/middleware.js
+++ b/packages/i18n-routes/templates/middleware.js
@@ -1,0 +1,18 @@
+import middleware from './middleware'
+
+middleware['i18n-routes'] = function ({isHMR, app, store, route, params, error, redirect}) {
+  // If middleware is called from hot module replacement, ignore it
+  if (isHMR) {
+    return
+  }
+
+  const urlLanguage = params.lang
+  if (urlLanguage) {
+    if (options.languages.indexOf(urlLanguage) === -1) {
+      return error({message: 'This page could not be found.', statusCode: 404})
+    }
+    store.commit('i18n-routes/setLanguage', urlLanguage)
+  }
+}
+
+const options = <%= serialize(options) %>

--- a/packages/i18n-routes/templates/plugin.js
+++ b/packages/i18n-routes/templates/plugin.js
@@ -1,0 +1,99 @@
+import Vue from 'vue'
+import VueI18n from 'vue-i18n'
+import './i18n-routes.middleware'
+
+Vue.use(VueI18n)
+
+export default ({app, store}) => {
+  registerStoreModule(store, 'i18n-routes', {
+    namespaced: true,
+    state: () => ({
+      language: null
+    }),
+    mutations: {
+      setLanguage (state, language) {
+        if (options.languages.indexOf(language) === -1) {
+          throw new Error('Invalid language: ' + language)
+        }
+        state.language = language
+        app.i18n.locale = language
+      }
+    }
+  })
+
+  let messages = {}
+  options.languages.forEach((lang) => {
+    messages[lang] = require('~/assets/locale/' + lang + '.json')
+  })
+  app.i18n = new VueI18n({
+    locale: store.state['i18n-routes'].language,
+    fallbackLocale: options.languages[0],
+    messages: messages,
+    silentTranslationWarn: true
+  })
+
+  Vue.use({
+    install (app) {
+      app.mixin({
+        methods: {
+          localePath (url) {
+            return '/' + store.state['i18n-routes'].language + url
+          },
+          detectLanguage () {
+            let languageList = []
+            if (typeof navigator !== 'undefined') {
+              if (navigator.userLanguage) {
+                languageList.unshift(navigator.userLanguage.substring(0, 2))
+              }
+              if (navigator.language) {
+                languageList.unshift(navigator.language.substring(0, 2))
+              }
+            }
+            let language = languageList.find((language) => {
+              return (options.languages.indexOf(language) !== -1)
+            })
+            return language || options.languages[0]
+          }
+        },
+        beforeMount () {
+          if (!this.$route.params.lang) {
+            this.$router.replace({params: {lang: this.detectLanguage()}})
+          }
+        },
+        head () {
+          if (!this.$route) {
+            return
+          }
+          let languageParamList = options.languages.concat(null)
+          let alternateLinks = languageParamList.map((languageParam) => {
+            let hreflang = (languageParam ? languageParam : 'x-default')
+            return {
+              hid: 'alternate-lang-' + hreflang,
+              rel: 'alternate',
+              hreflang: hreflang,
+              href: this.$router.resolve({params: {lang: languageParam}}).href
+            }
+          })
+          return {
+            link: alternateLinks
+          }
+        }
+      })
+    }
+  })
+}
+
+function registerStoreModule (store, name, definition) {
+  // See https://github.com/vuejs/vuex/issues/789#issuecomment-305241136
+  if (store.state[name]) {
+    const currentState = store.state[name]
+    const moduleState = definition.state
+    definition.state = () => {
+      definition.state = moduleState
+      return currentState
+    }
+  }
+  store.registerModule(name, definition)
+}
+
+const options = <%= serialize(options) %>


### PR DESCRIPTION
This is a draft for a module to automatically generate language-specific routes when using vue-i18n. Given a page "foo" it will generate routes for each language, plus a language-agnostic redirect page:
- **/en/foo**: English version
- **/de/foo**: German version
- **/foo**: Will detect the user's language on the *client side* and redirect to the appropriate language-URL.

I can see quite a demand and a lot of discussions about this topic: https://github.com/nuxt/nuxt.js/issues/2145, https://github.com/nuxt/nuxt.js/issues/1884, https://github.com/nuxt/nuxt.js/issues/1942, https://github.com/nuxt/nuxt.js/issues/1879, https://github.com/nuxt/nuxt.js/issues/112#issuecomment-340574312, https://github.com/paulgv/nuxt-i18n-routing.
Maybe Nuxt could provide a canonical way of generating localized routes with a module?

I'm attaching this code just to start the conversation. It's not as a generic solution as it would need to be yet.
If you think this is a bad idea, or there's another better way to solve this problem, please feel free to close this PR.
Either way, I'm happy for any input and feedback!

cc @christopheschwyzer