### PR TITLE
check if vueLoader.options.loaders exists

### DIFF
--- a/packages/markdownit/index.js
+++ b/packages/markdownit/index.js
@@ -21,7 +21,10 @@ module.exports = function nuxtMarkdownit (options) {
       if (vueLoader.query && vueLoader.query.loaders) {
         vueLoader.query.loaders['md'] = markDownItLoader
       } else {
-         // Sets options loaders (>= rc6)
+        // Sets options loaders (>= rc6)
+        if (!vueLoader.options.loaders) {
+          vueLoader.options.loaders = {}
+        }
         vueLoader.options.loaders['md'] = markDownItLoader
       }
       // .md Loader


### PR DESCRIPTION
check if vueLoader.options.loaders exists and create it if it doesn't. Object.assign would also be an option.

this addresses issue #207 

I guess this also has something to do with issue #203

I should note, the current module works fine with nuxt v1