### PR TITLE
markdownit plugin options fix

### DIFF
--- a/packages/markdownit/index.js
+++ b/packages/markdownit/index.js
@@ -60,7 +60,7 @@ module.exports = function nuxtMarkdownit (options) {
     this.addPlugin({
       src: path.resolve(__dirname, 'plugin.js'),
       fileName: 'markdown-it.js',
-      options: _options
+      options: options: Object.assign({}, options, this.options.markdownit)
     })
   }
 }


### PR DESCRIPTION
Originally, when `injected: true` in `nuxt.config.js`, plugins would only work through `$md.render()` and not through the template `<template lang="md"> ...`. Setting `injected: false` would allow plugins to work again.

In `markdownit/index.js`, passing in` _options` would prevent the non-injected markdown renderer from using plugins properly, because the array of plugins gets `array.shift()`ed

Using Object.assign lets the markdown renderer to use plugins both with `lang="md"` and through `$md.render()` when `injected: true`.