### PR TITLE
feat(google-tag-manager): Allow GTM ID to be function

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -21,7 +21,23 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 
 ### `id`
 - Required
-Should be in form of `GTM-XXXXXXX`
+- Can be String in form of `GTM-XXXXXXX`
+- Can be function returning Promise or String:
+```js
+// Returns Promise
+id: () => {
+  return axios.get('http://example.com/')
+    .then(({ data }) => {
+      return data.gtm_id
+    })
+}
+
+// Returns String
+const code = '1234567'
+id: () => {
+  return 'GTM-' + code
+}
+```
 
 ### All options
 ```js

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const { defaultsDeep } = require('lodash')
 
-module.exports = function nuxtTagManager(_options) {
+module.exports = async function nuxtTagManager(_options) {
   const options = defaultsDeep({}, _options, this.options['google-tag-manager'], {
     id: null,
     layer: 'dataLayer',
@@ -13,6 +13,10 @@ module.exports = function nuxtTagManager(_options) {
   // Don't include when no GTM id is given
   if (!options.id) {
     return
+  }
+
+  if (typeof (options.id) === 'function') {
+    options.id = await options.id()
   }
 
   // Build the <script> URL


### PR DESCRIPTION
This PR allows GTM ID to be function returning String or Promise, as shown in readme.md examples