### PR TITLE
[google-tag-manager] Do not include when run in dev mode

### DIFF
--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -11,7 +11,7 @@ module.exports = async function nuxtTagManager(_options) {
   })
 
   // Don't include when run in dev mode
-  if (this.nuxt.options.dev && process.env.NODE_ENV !== 'production') {
+  if (this.options.dev) {
     return
   }
 

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -10,6 +10,11 @@ module.exports = async function nuxtTagManager(_options) {
     query: {}
   })
 
+  // Don't include when run in dev mode
+  if (this.nuxt.options.dev && process.env.NODE_ENV !== 'production') {
+    return
+  }
+
   // Don't include when no GTM id is given
   if (!options.id) {
     return


### PR DESCRIPTION
Hi,

The README tells that google-tag-manager is not run in dev mode but it doesn't seems to work.
This PR should fix it.

Thanks !