### PR TITLE
Fixes wrong URL reporting

### DIFF
--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -8,7 +8,9 @@ window['<%= options.layer %>'].push({
 // Every time the route changes (fired on initialization too)
 export default ({ app: { router } }) => {
     router.afterEach((to, from) => {
-      window['<%= options.layer %>'].push(to.gtm || { event: 'nuxtRoute', pageType: 'PageView', pageUrl: to.fullPath, routeName: to.name })
+      setTimeout(() => {
+        window['<%= options.layer %>'].push(to.gtm || { event: 'nuxtRoute', pageType: 'PageView', pageUrl: to.fullPath, routeName: to.name })
+      }, 0)
     })
   }
 <% } %>


### PR DESCRIPTION
This fixes the incorrect variable reporting. Without this, if you inspect the raw variables in GTM preview mode, you'll see that `_url`, `Page URL` and `Page Path` are incorrectly reported. It reports the previous page, because when `router.afterEach` fires, I presume the internal browser data was not updated yet.