### PR TITLE
Merge options correctly

### DIFF
--- a/packages/ngrok/index.js
+++ b/packages/ngrok/index.js
@@ -23,9 +23,7 @@ module.exports = async function nuxtNgrok(options) {
     addr: `${host}:${port}`, // port or network address
   }
 
-  if (options && Object.keys(options).length) {
-    opts = Object.assign({}, opts, options)
-  }
+  opts = Object.assign({}, opts, this.options.ngrok, options)
 
   this.nuxt.hook('build:done', async () => {
     if (!connectedUrl) {


### PR DESCRIPTION
This allows us to combine multiple option sources.

```js
module.exports = {
    modules: [
        '@nuxtjs/ngrok'
    ],
    ngrok: {
        // read configuration from here too
    }
}
```