### PR TITLE
update instructions to use postcss-preset-env

### DIFF
--- a/packages/bulma/README.md
+++ b/packages/bulma/README.md
@@ -25,7 +25,7 @@ build: {
     */
     postcss: {
       plugins: {
-        'postcss-cssnext': {
+        'postcss-preset-env': {
           features: {
             customProperties: false
           }


### PR DESCRIPTION
postcss-cssnext is depreciated, update instructions to use postcss-preset-env