### PR TITLE
Updates error handler to reference ngrok error

### DIFF
--- a/packages/ngrok/index.js
+++ b/packages/ngrok/index.js
@@ -32,7 +32,7 @@ module.exports = async function nuxtNgrok(options) {
         connectedUrl = url
         return console.log(chalk.bgGreen.black(' OPEN ') + chalk.green(` ${connectedUrl} for external access`))
       } catch (err) {
-        return console.error('[nuxt][ngrok] ' + err)
+        return console.error('[nuxt][ngrok] ' + chalk.red(err.details.err))
       }
     }
     connectedUrl &&


### PR DESCRIPTION
The error returned by ngrok is an object with an error message contained within. 

Example error object:

```js
{ 
    error_code: 103,
    status_code: 502,
    msg: 'failed to start tunnel',
    details: { 
        err: 'Only paid plans may bind custom subdomains.\nFailed to bind the custom subdomain \'foobar\' for the account \'samturrell\'.\nThis account is on the \'Free\' plan.\n\nUpgrade to a paid plan at: https://dashboard.ngrok.com/billing/plan\n\nERR_NGROK_313\n' 
    } 
}
```

Adjusted the Nuxt error handler to reference this message rather than the entire object so that the feedback in the console is more useful than `[nuxt][ngrok] [object Object]`