### PR TITLE
Change google-tag-manager to allow local development

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -5,9 +5,6 @@
 > Add Google Tag Manager (GTM) to your nuxt.js application.
 This plugins automatically sends first page and route change events to GTM.
 
-**Note:** google tag manager is not enabled in dev mode.
-You can set environment variable `NODE_ENV` to `production` for testing in dev mode.
-
 ## Setup
 - Add `@nuxtjs/google-tag-manager` dependency using yarn or npm to your project
 - Add `@nuxtjs/google-tag-manager` to `modules` section of `nuxt.config.js`
@@ -39,6 +36,14 @@ id: () => {
 }
 ```
 
+### `enabled`
+
+Can be used to disable during development.
+
+```js
+enabled: process.env.NODE_ENV === 'production'
+```
+
 ### All options
 ```js
 {
@@ -51,7 +56,8 @@ id: () => {
     gtm_preview:     '...',
     gtm_cookies_win: '...'
   },
-  scriptURL: '//example.com'
+  scriptURL: '//example.com',
+  enabled: true
 }
 ```
 

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -8,11 +8,11 @@ module.exports = async function nuxtTagManager(_options) {
     pageTracking: false,
     respectDoNotTrack: false,
     env: {}, // env is supported for backward compability and is alias of query
-    query: {}
+    query: {},
+    enabled: true
   })
 
-  // Don't include when run in dev mode
-  if (this.options.dev) {
+  if (!this.options.enabled) {
     return
   }
 


### PR DESCRIPTION
At the moment you can’t test google-tag-manager without setting your env to production.

This just simply adds it as an option instead.