### PR TITLE
feat(toast): add ability to register custom toasts

### DIFF
--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -15,7 +15,16 @@
   ],
 
   toast: {
-      position: 'top-center'
+      position: 'top-center',
+      register: [ // Register custom toasts
+        {
+          name: 'my-error',
+          message: 'Oops...Something went wrong',
+          options: {
+            type: 'error'
+          }
+        }
+      ]
   }
 }
 ```
@@ -36,6 +45,7 @@ export default {
              await this.$axios.$post('auth/login')
              this.$toast.success('Successfully authenticated')
          } catch(e){
+             this.$toast.global.my_error() //Using custom toast
              this.$toast.error('Error while authenticating')
          }
      }  

--- a/packages/toast/index.js
+++ b/packages/toast/index.js
@@ -1,14 +1,17 @@
 const path = require('path')
 
 module.exports = function nuxtToast (moduleOptions) {
-  const options = Object.assign({}, this.options.toast, moduleOptions)
+  const { register, ...toastOptions } = Object.assign({}, this.options.toast, moduleOptions)
 
   // Register plugin
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
     ssr: false,
     fileName: 'toast.js',
-    options
+    options: {
+      register,
+      toastOptions
+    }
   })
 }
 

--- a/packages/toast/plugin.js
+++ b/packages/toast/plugin.js
@@ -1,7 +1,18 @@
 import Vue from 'vue'
 import Toasted from 'vue-toasted'
 
-Vue.use(Toasted, <%= serialize(options) %>)
+const opts = <%= serialize(options) %>
+var globals = []
+if(opts.hasOwnProperty('register')) {
+  globals = opts.register
+  delete opts.register
+}
+
+Vue.use(Toasted, opts)
+
+globals.forEach(global => {
+  Vue.toasted.register(global.name, global.message, global.options)
+})
 
 export default function (ctx, inject) {
   inject('toast', Vue.toasted)

--- a/packages/toast/plugin.js
+++ b/packages/toast/plugin.js
@@ -1,15 +1,9 @@
 import Vue from 'vue'
 import Toasted from 'vue-toasted'
 
-const opts = <%= serialize(options) %>
-var globals = []
-if(opts.hasOwnProperty('register')) {
-  globals = opts.register
-  delete opts.register
-}
+Vue.use(Toasted, <%= serialize(options.toastOptions) %>)
 
-Vue.use(Toasted, opts)
-
+const globals = <%= serialize(options.register) %>
 globals.forEach(global => {
   Vue.toasted.register(global.name, global.message, global.options)
 })

--- a/packages/toast/plugin.js
+++ b/packages/toast/plugin.js
@@ -4,9 +4,11 @@ import Toasted from 'vue-toasted'
 Vue.use(Toasted, <%= serialize(options.toastOptions) %>)
 
 const globals = <%= serialize(options.register) %>
-globals.forEach(global => {
-  Vue.toasted.register(global.name, global.message, global.options)
-})
+if(globals) {
+  globals.forEach(global => {
+    Vue.toasted.register(global.name, global.message, global.options)
+  })
+}
 
 export default function (ctx, inject) {
   inject('toast', Vue.toasted)


### PR DESCRIPTION
Trying to add the ability to register custom toasts from nuxt config.

It would look like this:

```  
toast: {
    position: 'bottom-right',
    register: [
      {
        name: 'test',
        message: (payload) => {
          if(!payload.message) return "Default message"
          return payload.message
        },
        options: {
          type : 'success',
          duration: 3000,
        }
      },
    ]
  },
```
Usage:
```
this.$toast.global.test()
this.$toast.global.test({ message: "Custom message here" } )
```