### PR TITLE
frat(toast): add typescript definitions

### DIFF
--- a/packages/toast/index.d.ts
+++ b/packages/toast/index.d.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import { Toasted } from 'vue-toasted'
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $toast: Toasted
+  }
+}

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.2",
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": "https://github.com/nuxt/modules",
   "homepage": "https://github.com/nuxt/modules/tree/master/modules/toast",
   "publishConfig": {


### PR DESCRIPTION
Hello,
I have add `index.d.ts` to toast module for allow use `this.$toast` in typescript.

Note: This PR is in draft because need this PR : https://github.com/shakee93/vue-toasted/pull/119

Thanks.