### PR TITLE
docs(markdownit): suggest using `markdown-it-div`

### DIFF
--- a/packages/markdownit/README.md
+++ b/packages/markdownit/README.md
@@ -20,7 +20,7 @@ Using [markdownit-loader](https://github.com/nuxt-community/markdownit-loader) a
     linkify: true,
     breaks: true,
     use: [
-      ['markdown-it-container', containerName],
+      'markdown-it-div',
       'markdown-it-attrs'
     ]
   }


### PR DESCRIPTION
Hi, I worked with markdown-it-container and it's mandatory containerName variable is harder to handle in application if we want to give a custom classes to divs. I found that with markdown-it-div plugin it's working out-of the box so I recommend to change it in README, cause it's not even listed in makdownit example plugins section.