### PR TITLE
fix(google-tag-manager): fix respectDoNotTrack

### DIFF
--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -13,7 +13,7 @@ class GTM {
       'gtm.start': new Date().getTime()
     })
 
-    if (!this.options.respectDoNotTrack && this.options.pageTracking && !this.hasDNT()) {
+    if (this.options.pageTracking && (!this.options.respectDoNotTrack || !this.hasDNT())) {
       this.initPageTracking()
     }
   }


### PR DESCRIPTION
The condition for initializing page tracking doesn't work properly:
```js
!this.options.respectDoNotTrack && this.options.pageTracking && !this.hasDNT()
```
Using `&&` everywhere means that setting `respectDoNotTrack` to true will prevent the entire condition from ever resolving to `true`, even if the user does not have the "do not track" setting to `true`.
Setting `respectDoNotTrack` to `true` means that the condition will only resolve to `true` if the user disables "dot not track" (and thus means that the user's "do not track" setting is then respected)