### PR TITLE
feat(google-tag-manager): add `<noscript>` fallback (#263)

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -43,6 +43,7 @@ id: () => {
   id: 'GTM-XXXXXXX',
   layer: 'dataLayer',
   pageTracking: false,
+  respectDoNotTrack: false,
   dev: true, // set to false to disable in dev mode
   query: {
     // query params...
@@ -50,13 +51,14 @@ id: () => {
     gtm_preview:     '...',
     gtm_cookies_win: '...'
   },
-  scriptURL: '//example.com'
+  scriptURL: '//example.com',
+  noscriptURL: '//example.com'
 }
 ```
 
 ### Router Integration
 
-You can optionally set `pageTracking` option to `true` to track page views. 
+You can optionally set `pageTracking` option to `true` to track page views.
 
 This is disabled by default to prevent double events when using alongside with Google Analytics so take care before enabling this option.
 

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -42,6 +42,11 @@ module.exports = async function nuxtTagManager(_options) {
     .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(queryParams[key])}`)
     .join('&')
 
+  // sanitization before to avoid errors like "cannot push to undefined"
+  this.options.head = this.options.head || {}
+  this.options.head.noscript = this.options.head.noscript || []
+  this.options.head.script = this.options.head.script || []
+
   // Add google tag manager script to head
   this.options.head.script.push({
     src: (options.scriptURL || '//www.googletagmanager.com/gtm.js') + '?' + queryString,

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -61,10 +61,8 @@ module.exports = async function nuxtTagManager(_options) {
   })
 
   // disables sanitazion for gtm noscript as we're using .innerHTML
-  this.options.head.__dangerouslyDisableSanitizersByTagID = Object.assign({}, this.options.head.__dangerouslyDisableSanitizersByTagID, {
-    'gtm-noscript': ['innerHTML']
-  })
-
+  this.options.head.__dangerouslyDisableSanitizersByTagID = this.options.head.__dangerouslyDisableSanitizersByTagID || {};
+  this.options.head.__dangerouslyDisableSanitizersByTagID['gtm-noscript'] = ['innerHTML']
 
   // Register plugin
   this.addPlugin({

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -8,8 +8,10 @@ module.exports = async function nuxtTagManager(_options) {
     pageTracking: false,
     respectDoNotTrack: false,
     dev: true,
-    env: {}, // env is supported for backward compability and is alias of query
-    query: {}
+    query: {},
+    scriptURL: '//www.googletagmanager.com/gtm.js',
+    noscriptURL: '//www.googletagmanager.com/ns.html',
+    env: {} // env is supported for backward compability and is alias of query
   })
 
   // Don't include when run in dev mode unless dev: true is configured
@@ -51,7 +53,7 @@ module.exports = async function nuxtTagManager(_options) {
   // https://github.com/nuxt/vue-meta/pull/410
   this.options.head.noscript.push({
     vmid: 'gtm-noscript',
-    innerHTML: `<iframe src="//www.googletagmanager.com/ns.html?id=${options.id}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+    innerHTML: `<iframe src="${(options.noscriptURL || '//www.googletagmanager.com/ns.html')}?${queryString}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
     body: true
   })
 

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -48,13 +48,11 @@ module.exports = async function nuxtTagManager(_options) {
     async: true
   })
 
-  // append google tag manager <noscript> fallback to <body>
-  // TODO: change it to prepend it to <body> once this one is merged + released:
-  // https://github.com/nuxt/vue-meta/pull/410
+  // prepend google tag manager <noscript> fallback to <body>
   this.options.head.noscript.push({
     vmid: 'gtm-noscript',
     innerHTML: `<iframe src="${(options.noscriptURL || '//www.googletagmanager.com/ns.html')}?${queryString}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
-    body: true
+    pbody: true
   })
 
   // disables sanitazion for gtm noscript as we're using .innerHTML

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -46,6 +46,19 @@ module.exports = async function nuxtTagManager(_options) {
     async: true
   })
 
+  // Add google tag manager noscript fallback to the beginning of <body>
+  this.options.head.noscript.push({
+    vmid: 'gtm-noscript',
+    innerHTML: `<iframe src="//www.googletagmanager.com/ns.html?id=${options.id}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+    body: true
+  })
+
+  // disables sanitazion for gtm noscript as we're using .innerHTML
+  this.options.head.__dangerouslyDisableSanitizersByTagID = Object.assign({}, this.options.head.__dangerouslyDisableSanitizersByTagID, {
+    'gtm-noscript': ['innerHTML']
+  })
+
+
   // Register plugin
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -46,7 +46,9 @@ module.exports = async function nuxtTagManager(_options) {
     async: true
   })
 
-  // Add google tag manager noscript fallback to the beginning of <body>
+  // append google tag manager <noscript> fallback to <body>
+  // TODO: change it to prepend it to <body> once this one is merged + released:
+  // https://github.com/nuxt/vue-meta/pull/410
   this.options.head.noscript.push({
     vmid: 'gtm-noscript',
     innerHTML: `<iframe src="//www.googletagmanager.com/ns.html?id=${options.id}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,


### PR DESCRIPTION
- Fixes #263 by adding a <noscript> fallback (as suggested here: https://developers.google.com/tag-manager/devguide)
- Adds example of all default options in Readme.md
