### PR TITLE
docs(bulma): update build config

### DIFF
--- a/packages/bulma/README.md
+++ b/packages/bulma/README.md
@@ -24,23 +24,10 @@ build: {
     ** You can extend webpack config here
     */
     postcss: {
-      plugins: {
-        'postcss-preset-env': {
-          features: {
-            customProperties: false
-          }
+      preset: {
+        features: {
+          customProperties: false
         }
-      }
-    },
-    extend(config, ctx) {
-      // Run ESLint on save
-      if (ctx.isDev && ctx.isClient) {
-        config.module.rules.push({
-          enforce: 'pre',
-          test: /\.(js|vue)$/,
-          loader: 'eslint-loader',
-          exclude: /(node_modules)/
-        })
       }
     }
   }


### PR DESCRIPTION
config in README is now the same as the config when creating a Nuxtjs+Bulma app with `create-nuxt-app`
- postcss config changed
- Run ESLint on save is not needed anymore, as `@nuxtjs/eslint-module` exists