### PR TITLE
feat(google-tag-manager): enable `respectDoNotTrack` by default

### DIFF
--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -6,7 +6,7 @@ module.exports = async function nuxtTagManager(_options) {
     id: null,
     layer: 'dataLayer',
     pageTracking: false,
-    respectDoNotTrack: false,
+    respectDoNotTrack: true,
     dev: true,
     env: {}, // env is supported for backward compability and is alias of query
     query: {}


### PR DESCRIPTION
How about being on the good side?