### PR TITLE
Fix(gtm): Broken Google Tag Manager Script URL

### DIFF
--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -9,7 +9,7 @@ module.exports = async function nuxtTagManager(_options) {
     respectDoNotTrack: false,
     dev: true,
     query: {},
-    scriptURL: '//www.googletagmanager.com/gtm.js',
+    scriptURL: '//googletagmanager.com/gtag/js',
     noscriptURL: '//www.googletagmanager.com/ns.html',
     env: {} // env is supported for backward compability and is alias of query
   })


### PR DESCRIPTION
When I install this package, it raises an error. It turns out that the GTM script URL has changed. The noscriptURL part is broken as well, but I can't figure out which is the right URL.