### PR TITLE
yandex-metrika: fix async and add preload

### DIFF
--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,24 +6,20 @@ module.exports = function yandexMetrika(options) {
     return;
   }
 
+  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js';
+
   // Script preload
   this.options.head.link.push({
-    href:
-      (options.useCDN
-        ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch'
-        : 'https://mc.yandex.ru/metrika') + '/watch.js',
+    href: metrikaUrl,
     rel: 'preload',
     as: 'script'
   });
 
   // Add yandex metrika script to head
   this.options.head.script.push({
-    src:
-      (options.useCDN
-        ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch'
-        : 'https://mc.yandex.ru/metrika') + '/watch.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
+    src: metrikaUrl, // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js
     async: 'true'
-  });
+  })
 
   // Register plugin
   this.addPlugin({

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -8,7 +8,7 @@ module.exports = function yandexMetrika(options) {
 
   // Script preload
   this.options.head.link.push({
-    href: src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js,
+    href: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js,
     rel: 'preload',
     as: 'script'
   })

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -1,19 +1,36 @@
-const path = require('path')
+const path = require('path');
 
-module.exports = function yandexMetrika (options) {
+module.exports = function yandexMetrika(options) {
   // Don't include on dev mode
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
-    return
+    return;
   }
+
+  // Script preload
+  this.options.head.link.push({
+    href:
+      (options.useCDN
+        ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch'
+        : 'https://mc.yandex.ru/metrika') + '/watch.js',
+    rel: 'preload',
+    as: 'script'
+  });
 
   // Add yandex metrika script to head
   this.options.head.script.push({
-    src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/watch.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
-    async: ''
-  })
+    src:
+      (options.useCDN
+        ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch'
+        : 'https://mc.yandex.ru/metrika') + '/watch.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
+    async: 'true'
+  });
 
   // Register plugin
-  this.addPlugin({src: path.resolve(__dirname, 'plugin.js'), ssr: false, options})
-}
+  this.addPlugin({
+    src: path.resolve(__dirname, 'plugin.js'),
+    ssr: false,
+    options
+  });
+};
 
-module.exports.meta = require('./package.json')
+module.exports.meta = require('./package.json');

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,18 +6,16 @@ module.exports = function yandexMetrika(options) {
     return;
   }
 
-  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js'
-
   // Script preload
   this.options.head.link.push({
-    href: metrikaUrl,
+    href: src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js,
     rel: 'preload',
     as: 'script'
   })
 
   // Add yandex metrika script to head
   this.options.head.script.push({
-    src: metrikaUrl, // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js
+    src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
     async: 'true'
   })
 

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('path')
 
 module.exports = function yandexMetrika(options) {
   // Don't include on dev mode
@@ -6,14 +6,14 @@ module.exports = function yandexMetrika(options) {
     return;
   }
 
-  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js';
+  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js'
 
   // Script preload
   this.options.head.link.push({
     href: metrikaUrl,
     rel: 'preload',
     as: 'script'
-  });
+  })
 
   // Add yandex metrika script to head
   this.options.head.script.push({
@@ -26,7 +26,7 @@ module.exports = function yandexMetrika(options) {
     src: path.resolve(__dirname, 'plugin.js'),
     ssr: false,
     options
-  });
+  })
 };
 
-module.exports.meta = require('./package.json');
+module.exports.meta = require('./package.json')


### PR DESCRIPTION
Without explicitly specifying true in the async attribute, Nuxt did not generate it when building the project. Also added preload for the script.