### PR TITLE
feat(google-tag-manager): add pageViewEventName option

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -43,6 +43,7 @@ id: () => {
   id: 'GTM-XXXXXXX',
   layer: 'dataLayer',
   pageTracking: false,
+  pageViewEventName: 'nuxtRoute',
   respectDoNotTrack: false,
   dev: true, // set to false to disable in dev mode
   query: {
@@ -61,6 +62,8 @@ id: () => {
 You can optionally set `pageTracking` option to `true` to track page views.
 
 This is disabled by default to prevent double events when using alongside with Google Analytics so take care before enabling this option.
+
+The default event name for page views is "nuxtRoute", you can change it by setting the `pageViewEventName` option.
 
 ## Usage
 

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -6,6 +6,7 @@ module.exports = async function nuxtTagManager(_options) {
     id: null,
     layer: 'dataLayer',
     pageTracking: false,
+    pageViewEventName: 'nuxtRoute',
     respectDoNotTrack: false,
     dev: true,
     query: {},

--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -21,7 +21,7 @@ class GTM {
   initPageTracking() {
     this.ctx.app.router.afterEach((to, from) => {
       setTimeout(() => {
-        window[this.options.layer].push(to.gtm || { event: 'nuxtRoute', pageType: 'PageView', pageUrl: to.fullPath, routeName: to.name })
+        window[this.options.layer].push(to.gtm || { event: this.options.pageViewEventName, pageType: 'PageView', pageUrl: to.fullPath, routeName: to.name })
       }, 0)
     })
   }


### PR DESCRIPTION
This PR adds the `pageViewEventName` option to allow changing the default `nuxtRoute` event name used for page views. 
`nuxtRoute` is very specific and not really friendly to marketing teams, plus the only way to know the event name is to read the code.