### PR TITLE
fix(google-tag-manager): fixed noscript content sanitization

### DIFF
--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -55,7 +55,7 @@ module.exports = async function nuxtTagManager(_options) {
 
   // prepend google tag manager <noscript> fallback to <body>
   this.options.head.noscript.push({
-    vmid: 'gtm-noscript',
+    hid: 'gtm-noscript',
     innerHTML: `<iframe src="${(options.noscriptURL || '//www.googletagmanager.com/ns.html')}?${queryString}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
     pbody: true
   })


### PR DESCRIPTION
The`noscript` tag gets included with the content sanitized. 
I'm pretty sure that's not the intended behavior for the content :)