### PR TITLE
feat(markdownit): Allows users to import local plugins

### DIFF
--- a/packages/markdownit/plugin.js
+++ b/packages/markdownit/plugin.js
@@ -1,10 +1,10 @@
 import MarkdownIt from 'markdown-it'
 
-function _requireCjs(module) {
-  if (module.__esModule) {
-    return module.default
+function _interopDefault (ex) {
+  if (ex && typeof ex === 'object' && 'default' in ex) {
+    return ex['default']
   }
-  return module
+  return ex
 }
 
 export default ({ app }, inject) => {
@@ -21,7 +21,7 @@ options = options === '{}' ? undefined : options
     const plugin = hasOpts ? config.shift(): config
     const opts = hasOpts ? config : []
 %>
-  md.use(_requireCjs(require('<%= plugin %>'))<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
+  md.use(_interopDefault(require('<%= plugin %>'))<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
 <% } %>
   inject('md', md)
 }

--- a/packages/markdownit/plugin.js
+++ b/packages/markdownit/plugin.js
@@ -1,5 +1,12 @@
 import MarkdownIt from 'markdown-it'
 
+function _requireCjs(module) {
+  if (module.__esModule) {
+    return module.default
+  }
+  return module
+}
+
 export default ({ app }, inject) => {
 <%
 const plugins = options.use || []
@@ -14,7 +21,7 @@ options = options === '{}' ? undefined : options
     const plugin = hasOpts ? config.shift(): config
     const opts = hasOpts ? config : []
 %>
-  md.use(require('<%= plugin %>')<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
+  md.use(_requireCjs(require('<%= plugin %>'))<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
 <% } %>
   inject('md', md)
 }


### PR DESCRIPTION
## Usage

nuxt.config.js
```
  markdownit: {
    injected: true,
    use: [
      '~/utils/markdown-it-local-plugin'
    ]
  }
```

~/utils/markdown-it-local-plugin.js
```
export default function markdownItPlugin (md) {
  // plugin
}
```

## Details

Currently,
if the plugin is written with ES6, you'd get this error: `plugin.apply is not a function`
if the plugin is written with CJS, you'd get this error on client side only: `exports is ready only`

In order to work on client side and server side, the only way I found is to add the conditional import in the PR.

EDIT: I've also tried to use the [`transpile` configuration](https://nuxtjs.org/api/configuration-build/#transpile) to transpile my local plugin to Common JS without success.