### PR TITLE
fix(yandex-metrika): preload and async

### DIFF
--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -5,11 +5,18 @@ module.exports = function yandexMetrika (options) {
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
     return
   }
+  
+  // Script preload
+  this.options.head.link.push({
+    href: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js,
+    rel: 'preload',
+    as: 'script'
+  })
 
   // Add yandex metrika script to head
   this.options.head.script.push({
     src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
-    async: ''
+    async: 'true'
   })
 
   // Register plugin

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,16 +6,18 @@ module.exports = function yandexMetrika (options) {
     return
   }
   
+  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js'; // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
+  
   // Script preload
   this.options.head.link.push({
-    href: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js,
+    href: metrikaUrl,
     rel: 'preload',
     as: 'script'
   })
 
   // Add yandex metrika script to head
   this.options.head.script.push({
-    src: (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js', // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
+    src: metrikaUrl,
     async: 'true'
   })
 


### PR DESCRIPTION
Without explicitly specifying true in the async attribute, Nuxt did not generate it when building the project. Also added preload for the script.