### PR TITLE
feat(toast): add `$toast` type definition to vuex context and application options

### DIFF
--- a/packages/toast/index.d.ts
+++ b/packages/toast/index.d.ts
@@ -1,6 +1,25 @@
 import Vue from 'vue'
 import { Toasted } from 'vue-toasted'
 
+declare module '@nuxt/vue-app' {
+  interface Context {
+    $toast: Toasted
+  }
+  interface NuxtAppOptions {
+    $toast: Toasted
+  }
+}
+
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface Context {
+    $toast: Toasted
+  }
+  interface NuxtAppOptions {
+    $toast: Toasted
+  }
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     $toast: Toasted


### PR DESCRIPTION
## About

`$toast` is [injected](https://github.com/nuxt-community/modules/blob/master/packages/toast/plugin.js#L14) into the application by the `inject` function, it can be used from Vuex as well as Vue components.
However, since it was not represented in the `.d.ts` file, I added a type definition.

