### PR TITLE
feat(google-tag-manager): add pushData method

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -73,3 +73,10 @@ You can push events into the configured `layer`:
 ```js
 this.$gtm.pushEvent({ event: 'myEvent', ...someAttributes })
 ```
+
+### Pushing data
+
+You can push data into the configured `layer`:
+```js
+this.$gtm.pushData({ 'key': 'value', 'other-key': 'other-value'})
+```

--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -43,6 +43,20 @@ class GTM {
     }
   }
 
+  pushData(obj) {
+    try {
+      if (!window || !window[this.options.layer]) {
+        throw new Error('missing GTM dataLayer')
+      }
+      if (typeof obj !== 'object') {
+        throw new Error('data should be an object')
+      }
+      window[this.options.layer].push(obj)
+    } catch (err) {
+      console.error('[ERROR] [GTM]', err)
+    }
+  }
+
   hasDNT() {
     return window.doNotTrack === '1' ||
       navigator.doNotTrack === 'yes' ||


### PR DESCRIPTION
I am trying to integrate [Google Analytics ecommerce](https://support.google.com/tagmanager/answer/6107169) using @nuxt/google-tag-manager.

The problem I am facing is that in the documentation for ecommerce tracking, I am supposed to push some information to the dataLayer, with no event attached. The code in the plugin only has one method to push stuff to the dataLayer, `pushEvent`, but this method requires an event, and fails to add the data to the dataLayer, because of the missing event attribute.

I added a new method `pushData` for this purpose, and added a reference to it in README.md.