### PR TITLE
adding scriptDefer option to the google-tag-manager plugin

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -52,6 +52,7 @@ id: () => {
     gtm_preview:     '...',
     gtm_cookies_win: '...'
   },
+  scriptDefer: false,
   scriptURL: '//example.com',
   noscriptURL: '//example.com'
 }

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -10,6 +10,7 @@ module.exports = async function nuxtTagManager(_options) {
     respectDoNotTrack: false,
     dev: true,
     query: {},
+    scriptDefer: false,
     scriptURL: '//www.googletagmanager.com/gtm.js',
     noscriptURL: '//www.googletagmanager.com/ns.html',
     env: {} // env is supported for backward compability and is alias of query
@@ -51,7 +52,8 @@ module.exports = async function nuxtTagManager(_options) {
   // Add google tag manager script to head
   this.options.head.script.push({
     src: (options.scriptURL || '//www.googletagmanager.com/gtm.js') + '?' + queryString,
-    async: true
+    async: (!options.scriptDefer),
+    defer: options.scriptDefer
   })
 
   // prepend google tag manager <noscript> fallback to <body>


### PR DESCRIPTION
To improve loading speeds for the application over tracking from GTM resources, it is better to use the defer attribute over the async attribute.  (see https://flaviocopes.com/javascript-async-defer/)

adding option for "scriptDefer" to the module.  But also leaving it default disabled, so that the behavior does not change unexpectedly for users of the module.

This is something we've wanted for ourselves.