### PR TITLE
fix(markdownit): `preset` configuration value was ignored

### DIFF
--- a/packages/markdownit/plugin.js
+++ b/packages/markdownit/plugin.js
@@ -2,12 +2,14 @@ import MarkdownIt from 'markdown-it'
 
 export default ({ app }, inject) => {
 <%
+const preset = options.preset || 'default'
+delete options.preset
 const plugins = options.use || []
 delete options.use
 options = serialize(options)
 options = options === '{}' ? undefined : options
 %>
-  const md = new MarkdownIt(<%= options %>)
+  const md = new MarkdownIt('<%= preset %>', <%= options %>)
 <%
   for (config of plugins) {
     const hasOpts = Array.isArray(config);


### PR DESCRIPTION
The MarkdownIt constructor did not take the 'preset' configuration value into account. The preset value should be the first parameter in the constructor.

This PR will take the preset and put it there.