### PR TITLE
Update Google Tag Manager package for initialisation flow

### DIFF
--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -53,9 +53,18 @@ id: () => {
     gtm_cookies_win: '...'
   },
   scriptURL: '//example.com',
-  noscriptURL: '//example.com'
+  noscriptURL: '//example.com',
+  autoInitOnClientSide: true,
+  presetScriptsOnServerSide: true
 }
 ```
+### GTM initialisation
+You can optionally set `autoInitOnClientSide` and `presetScriptsOnServerSide`. It can be helpful for full blocking Google Tag Manager before direct user selection. For example GDPR realisation or other.
+
+| Option name                 | Default value | Description                                                                                                                    |
+|-----------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `autoInitOnClientSide`      | true          | Send GTM event automatically. Also it is inserting GTM script and noscript elements, if there aren't presetted on server side. |
+| `presetScriptsOnServerSide` | true          | It is inserting GTM script on server side. It can be blocked with value `false`.                                               |
 
 ### Router Integration
 

--- a/packages/google-tag-manager/README.md
+++ b/packages/google-tag-manager/README.md
@@ -66,6 +66,11 @@ You can optionally set `autoInitOnClientSide` and `presetScriptsOnServerSide`. I
 | `autoInitOnClientSide`      | true          | Send GTM event automatically. Also it is inserting GTM script and noscript elements, if there aren't presetted on server side. |
 | `presetScriptsOnServerSide` | true          | It is inserting GTM script on server side. It can be blocked with value `false`.                                               |
 
+To initialize GTM programmatically you can use:
+```js
+this.$gtm.init()
+```
+
 ### Router Integration
 
 You can optionally set `pageTracking` option to `true` to track page views.

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -46,6 +46,9 @@ module.exports = async function nuxtTagManager(_options) {
     .join('&')
 
   // sanitization before to avoid errors like "cannot push to undefined"
+  const headScriptId = 'google-tag-manager-script'
+  const bodyScriptId = 'google-tag-manager-noscript'
+
   options.head = options.head || {}
   options.head.script = options.head.script || []
   options.head.noscript = options.head.noscript || []
@@ -56,17 +59,20 @@ module.exports = async function nuxtTagManager(_options) {
 
   const gtmScript = {
     src: (options.scriptURL || '//www.googletagmanager.com/gtm.js') + '?' + queryString,
+    id: headScriptId,
     async: true
   }
   const gtmNoScript = {
     hid: 'gtm-noscript',
     innerHTML: `<iframe src="${(options.noscriptURL || '//www.googletagmanager.com/ns.html')}?${queryString}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
+    id: bodyScriptId,
     pbody: true
   }
 
   options.head.script.push(gtmScript)
   options.head.noscript.push(gtmNoScript)
 
+  // Preset scripts on server side
   if (options.presetScriptsOnServerSide) {
     // Add google tag manager script to head
     this.options.head.script.push(gtmScript)

--- a/packages/google-tag-manager/index.js
+++ b/packages/google-tag-manager/index.js
@@ -12,7 +12,9 @@ module.exports = async function nuxtTagManager(_options) {
     query: {},
     scriptURL: '//www.googletagmanager.com/gtm.js',
     noscriptURL: '//www.googletagmanager.com/ns.html',
-    env: {} // env is supported for backward compability and is alias of query
+    env: {}, // env is supported for backward compability and is alias of query
+    autoInitOnClientSide: true,
+    presetScriptsOnServerSide: true
   })
 
   // Don't include when run in dev mode unless dev: true is configured
@@ -44,26 +46,38 @@ module.exports = async function nuxtTagManager(_options) {
     .join('&')
 
   // sanitization before to avoid errors like "cannot push to undefined"
-  this.options.head = this.options.head || {}
-  this.options.head.noscript = this.options.head.noscript || []
-  this.options.head.script = this.options.head.script || []
+  options.head = options.head || {}
+  options.head.script = options.head.script || []
+  options.head.noscript = options.head.noscript || []
 
-  // Add google tag manager script to head
-  this.options.head.script.push({
+  this.options.head = this.options.head || {}
+  this.options.head.script = this.options.head.script || []
+  this.options.head.noscript = this.options.head.noscript || []
+
+  const gtmScript = {
     src: (options.scriptURL || '//www.googletagmanager.com/gtm.js') + '?' + queryString,
     async: true
-  })
-
-  // prepend google tag manager <noscript> fallback to <body>
-  this.options.head.noscript.push({
+  }
+  const gtmNoScript = {
     hid: 'gtm-noscript',
     innerHTML: `<iframe src="${(options.noscriptURL || '//www.googletagmanager.com/ns.html')}?${queryString}" height="0" width="0" style="display:none;visibility:hidden"></iframe>`,
     pbody: true
-  })
+  }
 
-  // disables sanitazion for gtm noscript as we're using .innerHTML
-  this.options.head.__dangerouslyDisableSanitizersByTagID = this.options.head.__dangerouslyDisableSanitizersByTagID || {};
-  this.options.head.__dangerouslyDisableSanitizersByTagID['gtm-noscript'] = ['innerHTML']
+  options.head.script.push(gtmScript)
+  options.head.noscript.push(gtmNoScript)
+
+  if (options.presetScriptsOnServerSide) {
+    // Add google tag manager script to head
+    this.options.head.script.push(gtmScript)
+
+    // prepend google tag manager <noscript> fallback to <body>
+    this.options.head.noscript.push(gtmNoScript)
+
+    // disables sanitazion for gtm noscript as we're using .innerHTML
+    this.options.head.__dangerouslyDisableSanitizersByTagID = this.options.head.__dangerouslyDisableSanitizersByTagID || {};
+    this.options.head.__dangerouslyDisableSanitizersByTagID['gtm-noscript'] = ['innerHTML']
+  }
 
   // Register plugin
   this.addPlugin({

--- a/packages/google-tag-manager/package.json
+++ b/packages/google-tag-manager/package.json
@@ -7,5 +7,8 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "dependencies": {
+    "lodash": "^4.17.15"
+  }
 }

--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -6,6 +6,12 @@ class GTM {
     this.options = options
   }
   init() {
+
+    if (!this.options.presetScriptsOnServerSide) {
+      this.ctx.app.head.script.push(this.options.head.script[0])
+      this.ctx.app.head.noscript.push(this.options.head.noscript[0])
+    }
+
     window[this.options.layer] = window[this.options.layer] || []
 
     this.pushEvent({
@@ -54,10 +60,15 @@ class GTM {
 
 export default function(ctx, inject) {
   const options = <%= JSON.stringify(options) %>
+  const autoInit = options.autoInitOnClientSide
 
   // Create a new Auth instance
   const $gtm = new GTM(ctx, options)
   inject('gtm', $gtm)
+
+  if (!options.autoInitOnClientSide) {
+    return
+  }
 
   $gtm.init()
 }

--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -23,7 +23,7 @@ class GTM {
 
         bodyScript = document.createElement('noscript')
         bodyScript.id = bodyScriptId
-        bodyScript.text = this.options.head.noscript[0].innerHTML
+        bodyScript.innerHTML = this.options.head.noscript[0].innerHTML
 
         document.querySelector('head').append(headScript)
         document.querySelector('body').append(bodyScript)

--- a/packages/google-tag-manager/plugin.js
+++ b/packages/google-tag-manager/plugin.js
@@ -7,20 +7,15 @@ class GTM {
   }
   init() {
 
+    // insert scripts on client side if it not preseted on server side
     if (!this.options.presetScriptsOnServerSide) {
-      const isUniversalMode = this.ctx.nuxtState
-
-      this.ctx.app.head.script.push(this.options.head.script[0])
-      this.ctx.app.head.noscript.push(this.options.head.noscript[0])
-
-      // insert scripts on client side
       const headScriptId = 'google-tag-manager-script'
       const bodyScriptId = 'google-tag-manager-noscript'
 
       let headScript = document.querySelector(`script#${headScriptId}`)
       let bodyScript = document.querySelector(`script#${bodyScriptId}`)
 
-      if (isUniversalMode && !headScript && !bodyScript) {
+      if (!headScript && !bodyScript) {
         headScript = document.createElement('script')
         headScript.id = headScriptId
         headScript.src = this.options.head.script[0].src


### PR DESCRIPTION
Google Tag Manger initialisation.
It was not possible prevent auto activate GTM. 
Now there are two new options in module settings: 

- `autoInitOnClientSide` - Send GTM event automatically. Also it is inserting GTM script and noscript elements, if there aren't presetted on server side.
- `presetScriptsOnServerSide` - It is inserting GTM script on server side. It can be blocked with value false.

I also updated README.md file for these new options.
This can be very useful for implementing GDPR and other user scenarios.