### PR TITLE
fix(bulma): import order of the stylesheet

### DIFF
--- a/packages/bulma/index.js
+++ b/packages/bulma/index.js
@@ -2,7 +2,7 @@ const path = require('path')
 
 module.exports = function nuxtBulma(options) {
   // Add CSS
-  this.options.css.push('bulma/css/bulma.css')
+  this.options.css.unshift('bulma/css/bulma.css')
 }
 
 module.exports.meta = require('./package.json')


### PR DESCRIPTION
When working with third party stylesheets it's a common practice to add the third party stylesheet before of our custom stylesheet, so we can override the lib style rules.

But this module is inserting `bulma` in the end of css options in Nuxt config, this means that bulma css will be inserted after stylesheets defined in `css` option in `nuxt.config.js` and we cannot override the rules without a high priority selector or using `!important` :sweat: