### PR TITLE
fix(markdownit): intropDefault for plugin imports

### DIFF
--- a/packages/markdownit/plugin.js
+++ b/packages/markdownit/plugin.js
@@ -1,5 +1,7 @@
 import MarkdownIt from 'markdown-it'
 
+const handlePlugin = (plugin) => plugin.default || plugin
+
 export default ({ app }, inject) => {
 <%
 const plugins = options.use || []
@@ -14,7 +16,7 @@ options = options === '{}' ? undefined : options
     const plugin = hasOpts ? config.shift(): config
     const opts = hasOpts ? config : []
 %>
-  md.use(require('<%= plugin %>')<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
+  md.use(handlePlugin(require('<%= plugin %>'))<% for(opt of opts) { %>, <%= serialize(opt) %> <% } %>)
 <% } %>
   inject('md', md)
 }


### PR DESCRIPTION
It would be nice if  plugins could be exported as default and not only with module.export = ...