### PR TITLE
fix(markdownit): prevent mutating options (fixes #216)

### DIFF
--- a/packages/markdownit/index.js
+++ b/packages/markdownit/index.js
@@ -60,7 +60,7 @@ module.exports = function nuxtMarkdownit (options) {
     this.addPlugin({
       src: path.resolve(__dirname, 'plugin.js'),
       fileName: 'markdown-it.js',
-      options: _options
+      options: Object.asign({}, _options)
     })
   }
 }


### PR DESCRIPTION
Options are mutated by plugin creation so er have to clone it...