### PR TITLE
feat(yandex-metrika): use new version of yandex metrics code

### DIFF
--- a/packages/yandex-metrika/README.md
+++ b/packages/yandex-metrika/README.md
@@ -32,13 +32,28 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 
 ## Options
 For more information:
-- [Documetation for Ya.Metrika](https://yandex.com/support/metrica/code/counter-initialize.xml)
-- [hit method](https://yandex.com/support/metrica/objects/hit.xml)
+- [Documetation for Ya.Metrika](https://yandex.com/support/metrica/code/counter-initialize.html)
+- [hit method](https://yandex.com/support/metrica/objects/hit.html)
 
 ### `id`
 - Required
 
-### `webvisor`
-### `clickmap`
-### `trackLinks`
 ### `accurateTrackBounce`
+### `childIframe`
+### `clickmap`
+### `defer`
+### `ecommerce`
+### `params`
+### `userParams`
+### `trackHash`
+### `trackLinks`
+### `trustedDomains`
+### `type`
+### `useCDN`
+### `ut`
+### `webvisor`
+### `triggerEvent`
+
+
+
+

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -5,9 +5,9 @@ module.exports = function yandexMetrika (options) {
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
     return
   }
-  
-  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js'; // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
-  
+
+  const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js' // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
+
   // Script preload
   this.options.head.link.push({
     href: metrikaUrl,
@@ -22,7 +22,7 @@ module.exports = function yandexMetrika (options) {
   })
 
   // Register plugin
-  this.addPlugin({src: path.resolve(__dirname, 'plugin.js'), ssr: false, options})
+  this.addPlugin({ src: path.resolve(__dirname, 'plugin.js'), ssr: false, options })
 }
 
 module.exports.meta = require('./package.json')

--- a/packages/yandex-metrika/plugin.js
+++ b/packages/yandex-metrika/plugin.js
@@ -7,13 +7,13 @@ export default ({ app: { router } }) => {
   })
 
   function create() {
-    window['yaCounter<%= options.id %>'] = new Ya.Metrika2(<%= JSON.stringify(options) %>)
+    ym(<%= options.id %>, "init", <%= JSON.stringify(options) %>);
     router.afterEach((to, from) => {
       if (!ready) {
         // Don't record a duplicate hit for the initial navigation.
         return
       }
-      window['yaCounter<%= options.id %>'].hit(to.fullPath, {
+      ym(<%= options.id %>, 'hit', to.fullPath, {
         referer: from.fullPath
         // TODO: pass title: <new page title>
         // This will need special handling because router.afterEach is called *before* DOM is updated.
@@ -21,13 +21,15 @@ export default ({ app: { router } }) => {
     })
   }
 
-  if (window.Ya && window.Ya.Metrika2) {
-    // Yandex.Metrika API is already available.
-    create()
-  } else {
-    // Yandex.Metrika has not loaded yet, register a callback.
-    (function (w, c) {
-      (w[c] = w[c] || []).push(create)
-    })(window, 'yandex_metrika_callbacks')
+  if (window.ym === undefined) {
+    // Yandex.Metrika has not loaded yet, create ym method.
+    (function (m, i, k, a) {
+      m[i] = m[i] || function () {
+        (m[i].a = m[i].a || []).push(arguments)
+      }
+      m[i].l = 1 * new Date()
+    })
+    (window, "ym")
   }
+  create()
 }


### PR DESCRIPTION
Yandex metrics released a new version of the code (https://yandex.ru/blog/metrika/novyy-kod-v-nastroykakh-schetchika).

> The hit (url, [title [, referer [, params]]]) signature is outdated. It's supported for backward compatibility, but may be deprecated at any time. We strongly discourage using it. (https://yandex.ru/support/metrica/objects/hit.html)

New Code Initialization Information https://yandex.ru/support/metrica/code/counter-initialize.html.
