### PR TITLE
feat(yandex-metrika): support `yandexMetrika` option

### DIFF
--- a/packages/yandex-metrika/README.md
+++ b/packages/yandex-metrika/README.md
@@ -14,6 +14,14 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
 - Add `@nuxtjs/yandex-metrika` to `modules` section of `nuxt.config.js`
 ```js
 {
+  modules: ['@nuxtjs/yandex-metrika'],
+}
+```
+
+## Configure
+You can pass options directly in module declaration.
+```js
+{
   modules: [
     [
       '@nuxtjs/yandex-metrika',
@@ -28,7 +36,21 @@ You can set environment variable `NODE_ENV` to `production` for testing in dev m
     ],
   ]
 }
-````
+```
+Or you can specify `yandexMetrika` key.
+```js
+{
+  modules: ['@nuxtjs/yandex-metrika'],
+  yandexMetrika: {
+    id: 'XXXXXX',
+    webvisor: true,
+    // clickmap:true,
+    // useCDN:false,
+    // trackLinks:true,
+    // accurateTrackBounce:true,
+  },
+}
+```
 
 ## Options
 For more information:

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,7 +6,7 @@ module.exports = function yandexMetrika (moduleOptions) {
     return
   }
 
-  const options = { ...moduleOptions, ...(this.options.yandexMetrika || {}) }
+  const options = { ...(moduleOptions || {}), ...(this.options.yandexMetrika || {}) }
 
   const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js' // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
 

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -6,7 +6,7 @@ module.exports = function yandexMetrika (moduleOptions) {
     return
   }
 
-  const options = { ...moduleOptions, ...this.options.yandexMetrika }
+  const options = { ...moduleOptions, ...(this.options.yandexMetrika || {}) }
 
   const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js' // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
 

--- a/packages/yandex-metrika/index.js
+++ b/packages/yandex-metrika/index.js
@@ -1,10 +1,12 @@
 const path = require('path')
 
-module.exports = function yandexMetrika (options) {
+module.exports = function yandexMetrika (moduleOptions) {
   // Don't include on dev mode
   if (this.options.dev && process.env.NODE_ENV !== 'production') {
     return
   }
+
+  const options = { ...moduleOptions, ...this.options.yandexMetrika }
 
   const metrikaUrl = (options.useCDN ? 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch' : 'https://mc.yandex.ru/metrika') + '/tag.js' // add https://cdn.jsdelivr.net/npm/yandex-metrica-watch/watch.js
 


### PR DESCRIPTION
PR is pretty self-explanatory. It adds option to specify config in a separate key rather than in module declaration.
Before
---
```js
{
  modules: [
    [
      '@nuxtjs/yandex-metrika',
      {
        id: 'XXXXXX',
      },
    ],
  ]
}
```

After
---
```js
{
  modules: ['@nuxtjs/yandex-metrika'],
  yandexMetrika: {
    id: 'XXXXXX',
  },
}
```